### PR TITLE
fix "UnicodeDecodeError" in spelling.py under windows

### DIFF
--- a/src/checker/spelling.py
+++ b/src/checker/spelling.py
@@ -92,7 +92,7 @@ def read_pos_dictionaries(folder):
 def read_dictionary(dictionary, dictfile):
     lines = ""
     try:
-        fh = open(dictfile, 'r')
+        fh = open(dictfile, 'r', encoding='utf8')
         lines = fh.read()
         #print(lines); return
         fh.close()


### PR DESCRIPTION
Avoid an `UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 6386: character maps to <undefined>`  error being thrown under windows, because cp1252 encoding seems to be assumed on default, but the files in the repo are utf-8 encoded.