### PR TITLE
add failing test for division by zero

### DIFF
--- a/test/lib/test_stripper.py
+++ b/test/lib/test_stripper.py
@@ -1,0 +1,17 @@
+import unittest
+
+import re
+
+from papercheck.lib.stripper import stripTeX
+
+
+class StripperTest(unittest.TestCase):
+    def test_stripTeX__tex_only_input__result_has_no_chars(self):
+        result = stripTeX(
+            "['% document settings\n', '\\documentclass{latex4ei/latex4ei_report}\n', '\n', '\\usepackage{mathptmx} % assumes new font selection scheme installed\n', '\\usepackage{times} % assumes new font selection scheme installed\n', '\\usepackage{amsmath} % assumes amsmath package installed\n', '\\usepackage{amssymb}  % assumes amsmath package installed\n', '\\usepackage{cite}\n', '\\usepackage{hyperref}\n', '\\usepackage{textcomp}\n', '\\usepackage{tikz}\n', '\\usepackage{tabularx}\n', '\\usepackage{multirow}\n', '\\usepackage{caption}\n', '\\usepackage{tikzpeople}\n', '\\usepackage{float}\n', '\\usepackage[utf8]{inputenc}\n', '\\usepackage{marvosym}\n', '\\usepackage{stfloats}\n', '\\usepackage{pgfplots}\n', '\\usepackage{subcaption}\n', '\n', '\\usetikzlibrary{shapes}\n', '\\usetikzlibrary{intersections}\n', '\\usetikzlibrary{calc}\n', '\\usetikzlibrary{optics}\n', '\\usetikzlibrary{arrows}\n', '\\usetikzlibrary{positioning}\n', '\\usetikzlibrary{decorations}\n', '\\usetikzlibrary{angles}\n', '\\usetikzlibrary{quotes}\n', '\\usetikzlibrary{arrows.meta,shapes.geometric,decorations.pathreplacing}\n', '\n', '%\\clearpage\n', '\\addcontentsline{toc}{section}{References}\n', '\\bibliography{references}{}\n', '\\bibliographystyle{plain}\n', '\n', '\\end{document}\n']"
+        )
+        self.assertIsNone(re.search("[a-zA-Z]", result))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_textstats.py
+++ b/test/test_textstats.py
@@ -1,0 +1,13 @@
+import unittest
+
+from papercheck.textstats import createStats
+
+
+class TextStatsTest(unittest.TestCase):
+    def test_createStats__words_count_zero__valid_result(self):
+        result = createStats("\n\n\n\n\n")
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
While running papercheck I got a crash with 

```shell
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "./papercheck/__main__.py", line 357, in <module>
  File "./papercheck/__main__.py", line 282, in parseFile
  File "./papercheck/papercheck/textstats.py", line 130, in createStats
ZeroDivisionError: division by zero
```

@emareg  I added a unit test which reproduces this error, so you can fix this error by fixing the test.